### PR TITLE
fix: separate client init from common

### DIFF
--- a/src/main/java/duckmod/DuckEntityRenderer.java
+++ b/src/main/java/duckmod/DuckEntityRenderer.java
@@ -16,7 +16,7 @@ public class DuckEntityRenderer
 extends MobEntityRenderer<DuckEntity, DuckEntityModel<DuckEntity>> {
 
     public DuckEntityRenderer(EntityRendererFactory.Context context) {
-        super(context, new DuckEntityModel<duckmod.DuckEntity>(context.getPart(DuckMod.DUCK_LAYER)), 0.3f);
+        super(context, new DuckEntityModel<duckmod.DuckEntity>(context.getPart(DuckModClient.DUCK_LAYER)), 0.3f);
     }
 
     @Override

--- a/src/main/java/duckmod/DuckMod.java
+++ b/src/main/java/duckmod/DuckMod.java
@@ -31,9 +31,6 @@ public class DuckMod implements ModInitializer {
 	// Creates instance of duck egg item
 	public static final Item DUCK_EGG = new DuckEggItem(new Item.Settings().maxCount(16));
 
-
-	public static final EntityModelLayer DUCK_LAYER = new EntityModelLayer(new Identifier("duck", "duck"), "main");
-
 	//Thrown duck egg entity
 	public static final EntityType<DuckEggEntity> DUCK_EGG_ENTITY = Registry.register(
 		Registries.ENTITY_TYPE,
@@ -78,13 +75,6 @@ public class DuckMod implements ModInitializer {
 		//Mob registers
 		FabricDefaultAttributeRegistry.register(DUCK, DuckEntity.createDuckAttributes());
 
-		//Renderer register
-		EntityRendererRegistry.register(DuckMod.DUCK, (context) -> {
-			return new DuckEntityRenderer(context);
-		});
-		EntityModelLayerRegistry.registerModelLayer(DUCK_LAYER, DuckEntityModel::getTexturedModelData);
-		EntityRendererRegistry.register(DuckMod.DUCK_EGG_ENTITY, (dispatcher) -> new FlyingItemEntityRenderer<DuckEggEntity>(dispatcher, 1.0f,false));
-		
 		//Sound register
 		Registry.register(Registries.SOUND_EVENT, DuckMod.DUCK_SAY1_ID, DUCK_SAY1);
 		Registry.register(Registries.SOUND_EVENT, DuckMod.DUCK_SAY2_ID, DUCK_SAY2);

--- a/src/main/java/duckmod/DuckModClient.java
+++ b/src/main/java/duckmod/DuckModClient.java
@@ -1,0 +1,21 @@
+package duckmod;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.rendering.v1.EntityModelLayerRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.minecraft.client.render.entity.FlyingItemEntityRenderer;
+import net.minecraft.client.render.entity.model.EntityModelLayer;
+import net.minecraft.util.Identifier;
+
+public class DuckModClient implements ClientModInitializer {
+    public static final EntityModelLayer DUCK_LAYER = new EntityModelLayer(new Identifier("duck", "duck"), "main");
+
+
+    @Override
+    public void onInitializeClient() {
+        //Renderer register
+        EntityRendererRegistry.register(DuckMod.DUCK, DuckEntityRenderer::new);
+        EntityModelLayerRegistry.registerModelLayer(DUCK_LAYER, DuckEntityModel::getTexturedModelData);
+        EntityRendererRegistry.register(DuckMod.DUCK_EGG_ENTITY, (dispatcher) -> new FlyingItemEntityRenderer<DuckEggEntity>(dispatcher, 1.0f,false));
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -20,6 +20,9 @@
   "entrypoints": {
     "main": [
       "duckmod.DuckMod"
+    ],
+    "client": [
+      "duckmod.DuckModClient"
     ]
   },
   "mixins": [


### PR DESCRIPTION
this will help to prevent crashing when installed on server

Change log:
Created a new class `DuckModClient` and moved client init features from `DuckMod`
Reconfigured `fabric.mod.json` to init client separately
Imports corrected